### PR TITLE
Make the bridge compatible with Lumen

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ GoAopBridge can be easily installed with composer. Just ask a composer to downlo
 $ composer require goaop/goaop-laravel-bridge
 ```
 
+### Setup Laravel
 Add the `Go\Laravel\GoAopBridge\GoAopServiceProvider` to your config/app.php `providers` array:
 ```php
 // config/app.php
@@ -41,13 +42,34 @@ Add the `Go\Laravel\GoAopBridge\GoAopServiceProvider` to your config/app.php `pr
 ```
 Make sure that this service provider is the **first item** in this list. This is required for the AOP engine to work correctly.
 
+### Setup Lumen
+Register the `Go\Laravel\GoAopBridge\GoAopServiceProvider` to the app in your bootstrap/app.php:
+```php
+// bootstrap/app.php
+<?php
+// After `$app` is created
+
+$app->register(\Go\Laravel\GoAopBridge\GoAopServiceProvider::class);
+```
+Make sure that this service provider is the **first** call to `$app->register()`. This is required for the AOP engine to work correctly.
+
 Configuration
 -------------
 
-The default configuration in the `config/go_aop.php` file. Copy this file to your own config directory to modify the values. You can also publish the config using this command: 
+The default configuration in the `config/go_aop.php` file. If you want to change any of the default values you have to copy this file to your own config directory to modify the values. 
 
+If you use Laravel, you **can** also publish the config using this command:
 ```bash
 ./artisan vendor:publish --provider="Go\Laravel\GoAopBridge\GoAopServiceProvider"
+```
+
+If you use Lumen, you **have** to manually load the config file, example:
+```php
+// bootstrap/app.php
+<?php
+// After `$app` is created
+
+$app->configure('go_aop');
 ```
 
 Configuration can be used for additional tuning of AOP kernel and source code whitelistsing/blacklisting.
@@ -115,7 +137,7 @@ return [
      | leave it empty if you want AOP to be applied to all files in the appDir
      */
     'includePaths' => [
-        app_path()
+        app('path')
     ],
 
     /*

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["bridge", "laravel", "aop", "php", "aspect"],
     "require": {
         "goaop/framework": "^1.0|^2.0",
-        "laravel/framework": "^5.0"
+        "illuminate/support": "^5.0"
     },
     "license": "MIT",
     "authors": [

--- a/config/go_aop.php
+++ b/config/go_aop.php
@@ -68,7 +68,7 @@ return [
      | leave it empty if you want AOP to be applied to all files in the appDir
      */
     'includePaths' => [
-        app_path()
+        app('path')
     ],
 
     /*

--- a/src/GoAopServiceProvider.php
+++ b/src/GoAopServiceProvider.php
@@ -13,7 +13,6 @@ namespace Go\Laravel\GoAopBridge;
 use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
 use Go\Laravel\GoAopBridge\Kernel\AspectLaravelKernel;
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -55,7 +54,7 @@ class GoAopServiceProvider extends ServiceProvider
             return $aspectKernel;
         });
 
-        $this->app->singleton(AspectContainer::class, function (Application $app) {
+        $this->app->singleton(AspectContainer::class, function ($app) {
             /** @var AspectKernel $kernel */
             $kernel = $app->make(AspectKernel::class);
 


### PR DESCRIPTION
The bridge can be made compatible with Lumen applications with a few small modifications:

- require `illuminate/support` instead of the full Laravel framework
- do not type hint for `Illuminate\Contracts\Application`, the Lumen Application does not implement that interface
- do not use `app_path()`, this is a Laravel (actually `illuminate/foundation`) helper function. `app_path()` does literally `app('path')` 